### PR TITLE
Add a JSON formatter

### DIFF
--- a/src/formatters/json.js
+++ b/src/formatters/json.js
@@ -1,0 +1,34 @@
+/*global CSSLint*/
+CSSLint.addFormatter({
+    //format information
+    id: "json",
+    name: "JSON",
+
+    /**
+     * Return content to be printed before all file results.
+     * @return {String} to prepend before all results
+     */
+    startFormat: function() {
+        "use strict";
+        return "";
+    },
+
+    /**
+     * Return content to be printed after all file results.
+     * @return {String} to append after all results
+     */
+    endFormat: function() {
+        "use strict";
+        return "";
+    },
+
+    /**
+     * Given CSS Lint results for a file, return output for this format.
+     * @param results {Object} with error and warning messages
+     * @return {String} output for results
+     */
+    formatResults: function(results, filename, options) {
+        "use strict";
+        return options.quiet ? "" : JSON.stringify(results);
+    }
+});

--- a/tests/formatters/json.js
+++ b/tests/formatters/json.js
@@ -1,0 +1,33 @@
+(function(){
+    "use strict";
+    var Assert = YUITest.Assert;
+
+    YUITest.TestRunner.add(new YUITest.TestCase({
+
+        name: "JSON formatter",
+
+        "File with no problems should say so": function() {
+            var result = { messages: [], stats: [] },
+                actual = CSSLint.getFormatter("json").formatResults(result, "path/to/FILE", {fullPath: "/absolute/path/to/FILE"});
+            Assert.areEqual("{\"messages\":[],\"stats\":[]}", actual);
+        },
+
+        "Should have no output when quiet option is specified and no errors": function() {
+            var result = { messages: [], stats: [] },
+                actual = CSSLint.getFormatter("json").formatResults(result, "path/to/FILE", {fullPath: "/absolute/path/to/FILE", quiet: "true"});
+            Assert.areEqual("", actual);
+        },
+
+        "File with problems should list them": function() {
+            var result = { messages: [
+                { type: "warning", line: 1, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: [] },
+                { type: "error", line: 2, col: 1, message: "BOGUS", evidence: "ALSO BOGUS", rule: [] }
+            ], stats: [] },
+                expected = "{\"messages\":[{\"type\":\"warning\",\"line\":1,\"col\":1,\"message\":\"BOGUS\",\"evidence\":\"ALSO BOGUS\",\"rule\":[]},{\"type\":\"error\",\"line\":2,\"col\":1,\"message\":\"BOGUS\",\"evidence\":\"ALSO BOGUS\",\"rule\":[]}],\"stats\":[]}",
+                actual = CSSLint.getFormatter("json").formatResults(result, "path/to/FILE", {fullPath: "/absolute/path/to/FILE"});
+            Assert.areEqual(expected, actual);
+        }
+
+    }));
+
+})();


### PR DESCRIPTION
Add a JSON formatter option, allowing easier use in tools that have
native modes of parsing this output.
